### PR TITLE
Cleanup checkAdapter test databases after use

### DIFF
--- a/src/plugins/adapter-check.js
+++ b/src/plugins/adapter-check.js
@@ -28,6 +28,8 @@ export async function checkAdapter(adapter) {
         await pouch.remove(recoveredDoc);
     } catch (err) {
         return false;
+    } finally {
+        pouch && pouch.destroy && pouch.destroy()
     }
 
     if (recoveredDoc && recoveredDoc.value)


### PR DESCRIPTION
## This PR contains:
 - A BUGFIX

## Describe the problem you have without this PR
`checkAdapter` created test databases that were never deleted, cluttering up the developer tools storage tab.

## Todos
- [ ] Tests
- [ ] Changelog